### PR TITLE
Create a first-cut SPARQL app/library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+go_import_path: github.com/ross-spencer/spargo
+go:
+  - 1.13.1
+  - tip
+
+script:
+  - go test -v github.com/ross-spencer/spargo/pkg/spargo

--- a/README.md
+++ b/README.md
@@ -1,2 +1,92 @@
 # spargo
+
 SPARQL helper library for Golang
+
+[![Build Status](https://travis-ci.org/ross-spencer/spargo.svg?branch=master)](https://travis-ci.org/ross-spencer/spargo)
+[![GoDoc](https://godoc.org/github.com/ross-spencer/spargo?status.svg)](https://godoc.org/github.com/ross-spencer/spargo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/ross-spencer/spargo/pkg/spargo)](https://goreportcard.com/report/github.com/ross-spencer/spargo/pkg/spargo)
+
+## .sparql File Format
+
+The .sparql file format can be written as follows, note `#!spargo` is a magic
+number when used like this.
+
+```
+#!spargo
+
+ENDPOINT=...
+
+# Comment
+{sparql query}
+```
+
+## spargo interpreter
+
+Borrowing from the above, with spargo reachable via a path such as
+`/usr/bin/spargo` then a .sparql file can be configured like an interpretable
+script, so:
+
+```
+#!/usr/bin/spargo
+
+ENDPOINT=...
+
+# Comment
+{sparql query}
+```
+
+Lets call it `mysparql.sparql`. It can be run with executable permissions:
+
+```
+$ ./mysparql.sparql
+```
+
+And a JSON response will be returned to the caller.
+
+## spargo Command
+
+The `spargo` command primarily supports piped input, and there are some example
+queries that can help demonstrate that.
+
+In the spargo cmd folder, one can do the following:
+
+```
+github.com/ross-spencer/spargo/cmd/spargo$ cat examples/5-describe-wikidata.sparql | ./spargo
+
+Connecting to: https://query.wikidata.org/sparql
+
+Query: #! spargo
+# Describe JPEG2000 in Wikidata database.
+describe wd:Q931783
+
+...{result}...
+```
+
+## spargo Package
+
+The important part of this repository is the `spargo` package. To use it we
+can do something like as follows once it is imported.
+
+```golang
+package ...
+
+import (
+	...
+	...
+
+	"github.com/ross-spencer/spargo/pkg/spargo"
+)
+
+func ...() {
+	sparqlMe := spargo.SPARQLClient{}
+	sparqlMe.ClientInit(url, queryString)
+	res := sparqlMe.SPARQLGo().Human
+}
+```
+
+And the results will be available in the `res` variable to be consumed by your
+application.
+
+## License
+
+Apache License 2.0. More info [here](LICENSE).

--- a/cmd/spargo/examples/001-fr-magic.sparql
+++ b/cmd/spargo/examples/001-fr-magic.sparql
@@ -1,0 +1,14 @@
+#!/usr/bin/spargo
+
+ENDPOINT=http://the-fr.org/public/sparql/endpoint.php
+
+# Formats with container magic in the-fr.org
+SELECT ?s ?label ?puid ?version ?pronomlink ?binaryMagic ?containerMagic WHERE {
+  ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+  ?s <http://the-fr.org/prop/format-registry/version> ?version .
+  ?s <http://the-fr.org/prop/format-registry/puid> ?puid .
+  ?s <https://www.w3.org/2002/07/owl#sameAs> ?pronomlink .
+  ?s <http://digipres.org/formats/sources/pronom/formats/#hasMagic> true .
+  ?s <http://the-fr.org/prop/format-registry/hasPRONOMContainerMagic> ?containerMagic .
+  ?s <http://the-fr.org/prop/format-registry/hasPRONOMBinaryMagic> ?binaryMagic .
+}

--- a/cmd/spargo/examples/002-fr-raster.sparql
+++ b/cmd/spargo/examples/002-fr-raster.sparql
@@ -1,0 +1,9 @@
+#!/usr/bin/spargo
+
+ENDPOINT=http://the-fr.org/public/sparql/endpoint.php
+
+# Formats that are raster images in the-fr.org
+select distinct ?s ?label where {
+  ?s <http://the-fr.org/prop/format-registry/formatType> <http://the-fr.org/def/format-registry/RasterImage> .
+  ?s <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+} limit 20

--- a/cmd/spargo/examples/003-loc-in-wikidata.sparql
+++ b/cmd/spargo/examples/003-loc-in-wikidata.sparql
@@ -1,0 +1,11 @@
+#!/usr/bin/spargo
+
+ENDPOINT=https://query.wikidata.org/sparql
+
+# Wikidata and FDD link to fmt/134
+SELECT ?format ?puid ?ldd WHERE
+{
+  ?format wdt:P2748 "fmt/134".
+  ?format wdt:P2748 ?puid .
+  ?format wdt:P3266 ?ldd .
+}

--- a/cmd/spargo/examples/004-default-wikidata.sparql
+++ b/cmd/spargo/examples/004-default-wikidata.sparql
@@ -1,0 +1,11 @@
+#!/usr/bin/spargo
+
+ENDPOINT=https://query.wikidata.org/sparql
+
+# Default query example on Wikidata: NB. we can change the language here...
+SELECT ?item ?itemLabel
+WHERE
+{
+  ?item wdt:P31 wd:Q146.
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}

--- a/cmd/spargo/examples/005-describe-wikidata.sparql
+++ b/cmd/spargo/examples/005-describe-wikidata.sparql
@@ -1,0 +1,6 @@
+#!/usr/bin/spargo
+
+ENDPOINT=https://query.wikidata.org/sparql
+
+# Describe JPEG2000 in Wikidata database.
+describe wd:Q931783

--- a/cmd/spargo/examples/006-puids-in-wikidata
+++ b/cmd/spargo/examples/006-puids-in-wikidata
@@ -1,0 +1,13 @@
+#!/usr/bin/spargo
+
+ENDPOINT=https://query.wikidata.org/sparql
+
+SELECT ?format ?puid ?ldd ?formatLabel ?extension ?mimetype ?sig WHERE
+{
+  ?format wdt:P2748 ?puid.
+  OPTIONAL { ?format wdt:P3266 ?ldd }
+  OPTIONAL { ?format wdt:P1195 ?extension }
+  OPTIONAL { ?format wdt:P1163 ?mimetype }
+  OPTIONAL { ?format p:P4152 ?sig }
+  SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en". }
+}

--- a/cmd/spargo/spargo.go
+++ b/cmd/spargo/spargo.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/ross-spencer/spargo/pkg/spargo"
+)
+
+// SHEBANG provides some way of recognizing a .sparql file compatible with
+// spargo, aka. our .sparql magic number.
+var SHEBANG = []string{"#!spargo", "#!/usr/bin/spargo"}
+
+// ENDPOINT must be specified in a .sparql file so that a query can be sent to
+// the appropriate SPARQL endpoint.
+const ENDPOINT string = "ENDPOINT"
+
+var (
+	vers   bool
+	query  string
+	sparql string
+)
+
+func init() {
+	flag.StringVar(&sparql, "sparql", "", "first four bytes of file to find")
+	flag.StringVar(&sparql, "query", "", "return a single gif")
+	flag.BoolVar(&vers, "version", false, "Return version")
+}
+
+// Check for spargo shebang.
+func matchShebang(needle string, slice []string) bool {
+	for _, item := range slice {
+		if item == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// Extract the query from the .sparql input.
+func extractQuery(sparqlFile string) (string, string, error) {
+	var shebang, url, queryString string
+	var err error
+	for _, line := range strings.Split(sparqlFile, "\n") {
+
+		if line == "" {
+			// Pass.
+		} else if matchShebang(line, SHEBANG) {
+			shebang = line
+		} else if strings.Contains(strings.ToUpper(line), ENDPOINT) {
+			_url := strings.SplitN(line, "=", 2)
+			if len(_url) < 2 {
+				err = fmt.Errorf("incorrect endpoint formatting: %s", line)
+			}
+			// TODO: validate the URL.
+			url = strings.TrimSpace(_url[1])
+		} else {
+			queryString = queryString + line + "\n"
+		}
+	}
+	if shebang == "" {
+		err = fmt.Errorf("shebang '%s' is empty or incorrect", shebang)
+	}
+	return url, queryString, err
+}
+
+// TODO: Use a better pattern to parse the input of a SPARQL file...
+func runQuery(sparqlFile string) {
+	url, queryString, err := extractQuery(sparqlFile)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Fprintf(os.Stderr, "Connecting to: %s\n\n", url)
+	fmt.Fprintf(os.Stderr, "Query: %s\n\n", queryString)
+
+	sparqlMe := spargo.SPARQLClient{}
+	sparqlMe.ClientInit(url, queryString)
+	res := sparqlMe.SPARQLGo()
+
+	fmt.Println(res.Human)
+}
+
+func isPipeInput() bool {
+	info, err := os.Stdin.Stat()
+	if err != nil {
+		panic(err)
+	}
+	if (info.Mode() & os.ModeNamedPipe) != 0 {
+		return true
+	}
+	return false
+}
+
+// interpreterInput tests for a file as the second argument in a call to
+// spargo.
+//
+// TODO: there may be another pattern here using Open, but we are also
+//       anticipating other arguments to the program at different times, so...
+//
+func interpreterInput() (bool, string) {
+	if len(os.Args) == 2 {
+		sparql := os.Args[1]
+		if _, err := os.Stat(sparql); err == nil {
+			return true, sparql
+		} else if os.IsNotExist(err) {
+			// Does not exist.
+		} else {
+			// Another error.
+		}
+	}
+	return false, ""
+}
+
+func handlePipedInput() string {
+	reader := bufio.NewReader(os.Stdin)
+	var output []rune
+	for {
+		input, _, err := reader.ReadRune()
+		if err != nil && err == io.EOF {
+			break
+		}
+		output = append(output, input)
+	}
+	return string(output)
+}
+
+func handleInterpreterInput(sparql string) string {
+	data, err := ioutil.ReadFile(sparql)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func main() {
+	// Parse our input and let spargo generate a response.
+	if isPipeInput() {
+		queryString := handlePipedInput()
+		runQuery(queryString)
+		os.Exit(0)
+	} else {
+		_, sparql := interpreterInput()
+		if sparql != "" {
+			query := handleInterpreterInput(sparql)
+			runQuery(query)
+			os.Exit(0)
+		}
+	}
+	flag.Parse()
+	if vers {
+		fmt.Fprintf(os.Stderr, "%s \n", version())
+		os.Exit(0)
+	} else if flag.NFlag() == 0 {
+		fmt.Fprintln(os.Stderr, "Usage:  spargo {options}              ")
+		fmt.Fprintln(os.Stderr, "               OPTIONAL: [-sparql] ...")
+		fmt.Fprintln(os.Stderr, "               OPTIONAL: [-query]  ...")
+		fmt.Fprintln(os.Stderr, "               OPTIONAL: [-version]   ")
+		fmt.Fprintln(os.Stderr, "")
+		fmt.Fprintln(os.Stderr, "Output: [JSON]   {url}")
+		fmt.Fprintf(os.Stderr, "Output: [STRING] '%s ...'\n\n", version())
+		flag.Usage()
+		os.Exit(0)
+	} else {
+		// TODO: follow up with some defaults, and handling of CLI args.
+	}
+}

--- a/cmd/spargo/version.go
+++ b/cmd/spargo/version.go
@@ -1,0 +1,7 @@
+package main
+
+const versionString string = "spargo-0.0.1"
+
+func version() string {
+	return versionString
+}

--- a/pkg/spargo/spargo.go
+++ b/pkg/spargo/spargo.go
@@ -1,0 +1,110 @@
+package spargo
+
+/* Golang SPARQL package
+
+Enable the querying of a SPARQL data store using Golang.
+
+	"...Too rich for some people's tastes..."
+*/
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+// User-agent policy: https://meta.wikimedia.org/wiki/User-Agent_policy.
+const defaultAgent string = "spargo/0.0.1 (https://github.com/ross-spencer/spargo/; all.along.the.watchtower+github@gmail.com)"
+
+// TODO: Fix lazy error handling...
+func errorHandler(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// SPARQLClient ...
+type SPARQLClient struct {
+	Client  *http.Client
+	BaseURL string
+	Agent   string
+	Accept  string
+	Query   string
+}
+
+// SPARQLGo takes our SparqlEndpoint structure and packages that as a request
+// for our SPARQL endpoint of choice. For the given
+func (endpoint *SPARQLClient) SPARQLGo() SPARQLResult {
+
+	if endpoint.Client == nil {
+		endpoint.Client = &http.Client{}
+	}
+	endpoint.SetUserAgent("")
+	endpoint.SetAcceptHeader("")
+
+	req, err := http.NewRequest("GET", endpoint.BaseURL, nil)
+	errorHandler(err)
+
+	req.Header.Add("User-Agent", endpoint.Agent)
+	req.Header.Add("Accept", endpoint.Accept)
+
+	query := req.URL.Query()
+	query.Add("query", endpoint.Query)
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := endpoint.Client.Do(req)
+	defer resp.Body.Close()
+
+	errorHandler(err)
+	if resp.StatusCode != 200 {
+		log.Printf("Error: unknown response from server: %s", resp.Status)
+		return SPARQLResult{}
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	errorHandler(err)
+
+	var sparqlResponse SPARQLResult
+	sparqlResponse.Human = string(body)
+
+	err = json.Unmarshal(body, &sparqlResponse)
+	errorHandler(err)
+
+	return sparqlResponse
+}
+
+// SetUserAgent agent allows the user to set a custom user agent or use the
+// library's default.
+func (endpoint *SPARQLClient) SetUserAgent(agent string) {
+	if agent == "" {
+		agent = defaultAgent
+	}
+	endpoint.Agent = agent
+}
+
+// SetQuery enables us to set the SPARQL query.
+func (endpoint *SPARQLClient) SetQuery(queryString string) {
+	if queryString == "" {
+		// Shall we perform some error handling here?
+	}
+	endpoint.Query = queryString
+}
+
+// SetAcceptHeader will allow us to request results in other data formats. Our
+// default is SPARQL JSON.
+func (endpoint *SPARQLClient) SetAcceptHeader(accept string) {
+	endpoint.Accept = "application/sparql-results+json, application/json"
+}
+
+// SetURL lets us set the URL of the SPARQL endpoint to query.
+func (endpoint *SPARQLClient) SetURL(url string) {
+	endpoint.BaseURL = url
+}
+
+// ClientInit provides us with a helper function to set endpoint URL and
+// query string in a single go.
+func (endpoint *SPARQLClient) ClientInit(url string, queryString string) {
+	endpoint.SetURL(url)
+	endpoint.SetQuery(queryString)
+}

--- a/pkg/spargo/spargo_test.go
+++ b/pkg/spargo/spargo_test.go
@@ -1,0 +1,70 @@
+package spargo
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// More on round-trip: http://hassansin.github.io/Unit-Testing-http-client-in-Go
+
+// RoundTripFunc
+type RoundTripFunc func(req *http.Request) *http.Response
+
+// RoundTrip
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+// NewTestClient returns *http.Client with Transport replaced to avoid making real calls
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: RoundTripFunc(fn),
+	}
+}
+
+func TestSparqlHandler(t *testing.T) {
+	client := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: 200,
+			// Send response to be tested
+			Body: ioutil.NopCloser(bytes.NewBufferString(testString)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+
+	c := SPARQLClient{}
+	c.Client = client
+	c.ClientInit("http://example.com", testQuery)
+	response := c.SPARQLGo()
+
+	results := response.Results.Bindings
+	if len(results) != 2 {
+		t.Errorf("Anticipated length of 2, received %d", len(results))
+	}
+
+	expectedRes := []string{
+		"http://the-fr.org/id/file-format/25",
+		"OS/2 Bitmap",
+		"http://the-fr.org/id/file-format/28",
+		"CALS Compressed Bitmap",
+	}
+
+	var receivedRes []string
+	for _, res := range results {
+		for _, item := range res {
+			receivedRes = append(receivedRes, item.Value)
+		}
+	}
+
+	// FIXME: (Unless this works) Order of slices is not predictable in Golang.
+	sort.Strings(receivedRes)
+	sort.Strings(expectedRes)
+	if reflect.DeepEqual(receivedRes, expectedRes) != true {
+		t.Error("Result arrays are not equal")
+	}
+}

--- a/pkg/spargo/sparql_results.go
+++ b/pkg/spargo/sparql_results.go
@@ -1,0 +1,59 @@
+package spargo
+
+/*
+Basic SPARQL results will be returned as follows:
+
+	{
+	   "head":{
+	      "vars":[
+	         "item",
+	         "itemLabel"
+	      ]
+	   },
+	   "results":{
+	      "bindings":[
+	         {
+	            "predicate_one":{
+	               "type":"uri",
+	               "value":"http://www.wikidata.org/entity/Q28114535"
+	            },
+	            "predicate_two":{
+	               "xml:lang":"en",
+	               "type":"literal",
+	               "value":"Mr. White"
+	            }
+	         },
+	         {
+	            "predicate_one":{
+	               "type":"uri",
+	               "value":"http://www.wikidata.org/entity/Q28665865"
+	            },
+	            "predicate_two":{
+	               "xml:lang":"en",
+	               "type":"literal",
+	               "value":"Мyka"
+	            }
+	         }
+	      ]
+	   }
+	}
+
+*/
+
+type item struct {
+	Lang     string `json:"xml:lang"` // Populated if requested in query.
+	Type     string // Can be "uri", "literal"
+	Value    string
+	DataType string
+}
+
+type binding struct {
+	Bindings []map[string]item
+}
+
+// SPARQLResult packages a SPARQL response from an endpoint.
+type SPARQLResult struct {
+	Head    map[string]interface{}
+	Results binding
+	Human   string
+}

--- a/pkg/spargo/strings_test.go
+++ b/pkg/spargo/strings_test.go
@@ -1,0 +1,41 @@
+package spargo
+
+var testQuery = `select distinct ?s ?label where {
+	?s <http://the-fr.org/prop/format-registry/formatType> <http://the-fr.org/def/format-registry/RasterImage> .
+	?s <http://www.w3.org/2000/01/rdf-schema#label> ?label .
+} limit 10`
+
+var testString = `{
+   "head":{
+      "vars":[
+         "s",
+         "label"
+      ]
+   },
+   "results":{
+      "bindings":[
+         {
+            "s":{
+               "type":"uri",
+               "value":"http://the-fr.org/id/file-format/25"
+            },
+            "label":{
+               "type":"literal",
+               "value":"OS/2 Bitmap",
+               "xml:lang":"en"
+            }
+         },
+         {
+            "s":{
+               "type":"uri",
+               "value":"http://the-fr.org/id/file-format/28"
+            },
+            "label":{
+               "type":"literal",
+               "value":"CALS Compressed Bitmap",
+               "xml:lang":"en"
+            }
+         }
+      ]
+   }
+}`


### PR DESCRIPTION
A first attempt at a custom library for handling SPARQL queries in Golang, written to be entirely 'in-house'. 

cc. @richardlehane -- just trying to get rid of the ring-rust, it'd be great to get a bit of a CR on this, plus a little advice on code layout. I'm thinking a general purpose exe would be great, as well as a library for obvious reasons. Usually I create a library in one repo (so could hand this over) and then I create an exe separately, which may still prove to be the best way here. Anyway! Let me know. Will touch base via DM. 

Connected to #1 
